### PR TITLE
Add future moving-average targets & leakage prevention in training script

### DIFF
--- a/src/scripts/train_timesnet_from_csv.py
+++ b/src/scripts/train_timesnet_from_csv.py
@@ -315,6 +315,14 @@ def main():
 
     args = ap.parse_args()
 
+    # Sanity checks on args
+    if any(col.endswith("_MA_future") for col in args.features):
+        raise ValueError(
+            "Future-based target columns (e.g., High_MA_future, Low_MA_future) "
+            "must NOT be included in --features. "
+            "They contain future information and would leak data into the model."
+        )
+
     set_repro(args.seed)
     args.out.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
### Summary
This PR introduces support for generating future moving-average target columns 
(e.g. High_MA_future, Low_MA_future) during dataset splitting.

### Changes
- Added `add_future_moving_averages()` to split_dataset.py
- Applied future target creation to train/val/test splits
- Added leakage-prevention guard: forbid any *_MA_future column in `--features`